### PR TITLE
"Identifier" misspelled as "Identifer"

### DIFF
--- a/usr/share/openmediavault/workbench/component.d/omv-services-anacron-datatable-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-services-anacron-datatable-page.yaml
@@ -31,7 +31,7 @@ data:
         prop: delay
         flexGrow: 1
         sortable: true
-      - name: _("Identifer")
+      - name: _("Identifier")
         prop: identifier
         flexGrow: 1
         sortable: true


### PR DESCRIPTION
When doing translation, I found "Identifier" is misspelled as "Identifer". Of course, all language files have to be updated too.