### PR TITLE
ensure that identifier has no spaces, no slashes and is not empty. 

### DIFF
--- a/srv/salt/omv/deploy/anacron/10omvanacron.sls
+++ b/srv/salt/omv/deploy/anacron/10omvanacron.sls
@@ -1,22 +1,27 @@
 {%- set config = salt['omv_conf.get']('conf.service.anacron') %}
 {%- for task in config.tasks.task  | selectattr('enable') %}
 {%- set end = ">/dev/null 2>&1" %}
+{%- if task.identifier | length > 0 %}
+{%- set identifier = task.identifier | replace(' ', '_') | replace('/', '') %}
+{%- else %}
+{%- set identifier = task.command | replace(' ', '_') | replace('/', '') %}
+{%- endif %}
 {%- if task.sendemail | to_bool %}
-{%- set subject = task.identifier %}
+{%- set subject = identifier %}
 {%- if task.comment | length > 0 %}
 {%- set subject = [subject, '::', task.comment] | join (' ') | replace('\n', ' ') %}
 {%- endif %}
 create_anacron_task_{{ task.uuid }}:
   file.accumulated:
     - filename: "/etc/anacrontab"
-    - text: "{{ task.period }}\t{{ task.delay }}\t{{ task.identifier }}\t{{ task.command }} | mail -E -s \"Anacron - {{ subject }}\" -a \"From: Anacron Daemon <{{ task.username }}>\" {{ task.username }}{{ end }}" 
+    - text: "{{ task.period }}\t{{ task.delay }}\t{{ identifier }}\t{{ task.command }} | mail -E -s \"Anacron - {{ subject }}\" -a \"From: Anacron Daemon <{{ task.username }}>\" {{ task.username }}{{ end }}" 
     - require_in:
       - file: append_anacron_entries
 {%- else %}
 create_anacron_task_{{ task.uuid }}:
   file.accumulated:
     - filename: "/etc/anacrontab"
-    - text: "{{ task.period }}\t{{ task.delay }}\t{{ task.identifier }}\t{{ task.command }} {{ end }}"
+    - text: "{{ task.period }}\t{{ task.delay }}\t{{ identifier }}\t{{ task.command }} {{ end }}"
     - require_in:
       - file: append_anacron_entries
 {%- endif %}


### PR DESCRIPTION
Ensure that identifier has no spaces, no slashes and is not empty. set command as default identifier if empty.

This issue has been discussed in https://forum.openmediavault.org/index.php?thread/44544-anacron-is-not-running-its-tasks/

This PR fixes this issue.